### PR TITLE
[Typos] Fixed typo vechicleId=>vehicleId

### DIFF
--- a/src/fetchManualPage.ts
+++ b/src/fetchManualPage.ts
@@ -2,7 +2,7 @@ import client from "./client";
 import { stringify } from "qs";
 
 export interface FetchManualPageParams {
-  vechicleId: string;
+  vehicleId: string;
   modelYear: string;
   channel: string;
   book: string;

--- a/src/fetchTreeAndCover.ts
+++ b/src/fetchTreeAndCover.ts
@@ -13,7 +13,7 @@ export default async function fetchTreeAndCover(
 ): Promise<{ tableOfContents: any; pageHTML: string }> {
   const req = await client({
     method: "POST",
-    url: `https://www.fordservicecontent.com/Ford_Content/PublicationRuntimeRefreshPTS//publication/prod_1_3_362022/TreeAndCover/workshop/${params.category}/~WS8B/${params.vechicleId}`,
+    url: `https://www.fordservicecontent.com/Ford_Content/PublicationRuntimeRefreshPTS//publication/prod_1_3_362022/TreeAndCover/workshop/${params.category}/~WS8B/${params.vehicleId}`,
     params: {
       bookTitle: params.bookTitle,
       WiringBookTitle: params.WiringBookTitle,

--- a/src/wiring/saveEntireWiring.ts
+++ b/src/wiring/saveEntireWiring.ts
@@ -47,7 +47,7 @@ export default async function saveEntireWiring(
           language: fetchManualParams.contentlanguage,
           cell: doc.Number,
           page: "1",
-          vehicleId: fetchManualParams.vechicleId,
+          vehicleId: fetchManualParams.vehicleId,
           bookType: fetchWiringParams.bookType,
           country: fetchManualParams.contentmarket,
           title: doc.Title,

--- a/templates/params.json
+++ b/templates/params.json
@@ -1,6 +1,6 @@
 {
   "workshop": {
-    "vechicleId": "123",
+    "vehicleId": "123",
     "modelYear": "0000",
     "channel": "9",
     "book": "S0X",


### PR DESCRIPTION
`vehicleId `was misspelled as `vechicleId`, and it was driving me crazy trying to troubleshoot another issue 