### PR TITLE
Add remote browser mode support (alongside managed Playwright launch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "command-line-args": "^5.2.1",
     "command-line-usage": "^6.1.1",
     "jsdom": "^19.0.0",
-    "playwright": "^1.42.1",
+    "playwright": "^1.57.0",
     "qs": "^6.10.3",
     "svg-to-img": "^2.0.9"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,4 +25,8 @@ const client = axios.create({
     : false,
 });
 
+export const setCookies = (cookies: string) => {
+  client.defaults.headers.common["Cookie"] = cookies;
+};
+
 export default client;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { writeFile, readFile, mkdir } from "fs/promises";
+import { writeFile, readFile, mkdir, access } from "fs/promises";
 import fetchTreeAndCover, {
   FetchTreeAndCoverParams,
 } from "./workshop/fetchTreeAndCover";
@@ -7,20 +7,67 @@ import fetchTableOfContents, {
 } from "./wiring/fetchTableOfContents";
 import saveEntireWiring from "./wiring/saveEntireWiring";
 import transformCookieString from "./transformCookieString";
-import { chromium, Page, BrowserContext } from "playwright";
+import {
+  chromium,
+  Page,
+  BrowserContext,
+  LaunchOptions,
+  Browser,
+} from "playwright";
 import { join } from "path";
-import saveEntireManual from "./workshop/saveEntireManual";
+import saveEntireManual, { SaveOptions } from "./workshop/saveEntireManual";
 import readConfig, { Config } from "./readConfig";
 import processCLIArgs, { CLIArgs } from "./processCLIArgs";
 import fetchPre2003AlphabeticalIndex from "./pre-2003/fetchAlphabeticalIndex";
 import saveEntirePre2003AlphabeticalIndex from "./pre-2003/saveEntireAlphabeticalIndex";
-import client from "./client";
+import client, { setCookies } from "./client";
 import {
   USER_AGENT,
   SEC_CH_UA,
   ENV_USE_PROXY,
   ENV_HEADLESS_BROWSER,
 } from "./constants";
+
+const fileExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+type BrowserCookies = Awaited<ReturnType<BrowserContext["cookies"]>>;
+
+const COOKIE_SOURCE_URLS = [
+  "https://www.fordtechservice.dealerconnection.com",
+  "https://www.fordservicecontent.com",
+];
+
+const serializeCookies = (cookies: BrowserCookies): string =>
+  cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join("; ");
+
+const getCookieHeaderFromContext = async (
+  context: BrowserContext
+): Promise<string> => {
+  for (const url of COOKIE_SOURCE_URLS) {
+    const header = serializeCookies(await context.cookies(url));
+    if (header) {
+      return header;
+    }
+  }
+
+  const fallback = serializeCookies(
+    (await context.cookies()).filter((cookie) =>
+      cookie.domain
+        ? cookie.domain.includes("dealerconnection.com") ||
+          cookie.domain.includes("fordservicecontent.com")
+        : false
+    )
+  );
+
+  return fallback;
+};
 
 async function run({
   configPath,
@@ -30,9 +77,33 @@ async function run({
   doWiringDownload,
   doParamsValidation,
   doCookieTest,
-  ...restArgs
+  saveHTML,
+  ignoreSaveErrors,
+  browserMode,
+  remoteDebuggingUrl,
 }: CLIArgs) {
   const config = await readConfig(configPath, doParamsValidation);
+  const saveOptions: SaveOptions = { saveHTML, ignoreSaveErrors };
+  const isRemoteBrowser = browserMode === "remote";
+  let rawCookieString = "";
+  let transformedCookies: Parameters<BrowserContext["addCookies"]>[0] = [];
+  let processedCookieString = "";
+
+  if (!isRemoteBrowser) {
+    console.log("Processing cookies...");
+    rawCookieString = (await readFile(cookiePath, { encoding: "utf-8" }))
+      .trim()
+      .replaceAll("\n", " ");
+    const cookieData = transformCookieString(rawCookieString);
+    transformedCookies = cookieData.transformedCookies;
+    processedCookieString = cookieData.processedCookieString;
+
+    // Add the cookie string to the Axios client
+    // It'll be sent with every request automatically
+    setCookies(processedCookieString);
+  } else {
+    console.log("Using cookies from the connected Chrome session...");
+  }
 
   // create output dir
   try {
@@ -44,70 +115,224 @@ async function run({
     }
   }
 
-  console.log("Processing cookies...");
-  const rawCookieString = (await readFile(cookiePath, { encoding: "utf-8" }))
-    .trim()
-    .replaceAll("\n", " ");
-  const { transformedCookies, processedCookieString } =
-    transformCookieString(rawCookieString);
+  const cacheDir = join(process.cwd(), ".cache");
+  try {
+    await mkdir(cacheDir, { recursive: true });
+  } catch (e: any) {
+    if (e.code !== "EEXIST") {
+      console.error(`Error creating cache directory ${cacheDir}: ${e}`);
+      process.exit(1);
+    }
+  }
 
-  // Add the cookie string to the Axios client
-  // It'll be sent with every request automatically
-  client.defaults.headers.Cookie = processedCookieString;
+  const storageStatePath = join(cacheDir, "playwright-storage-state.json");
+  const storageStateExists = await fileExists(storageStatePath);
+  let browser: Browser;
+  if (isRemoteBrowser) {
+    console.log(
+      `Connecting to an existing Chrome instance at ${remoteDebuggingUrl}...`
+    );
+    try {
+      browser = await chromium.connectOverCDP(remoteDebuggingUrl);
+    } catch (error) {
+      console.error(
+        `Failed to connect to Chrome via ${remoteDebuggingUrl}. ` +
+          "Make sure Chrome is started with --remote-debugging-port and retry."
+      );
+      console.error(error);
+      process.exit(1);
+    }
+  } else {
+    console.log("Creating a chromium instance...");
+    const launchArgs: LaunchOptions["args"] = [
+      // fix getting wiring SVGs while keeping the rest of the browser close to stock
+      "--disable-web-security",
+      "--disable-blink-features=AutomationControlled",
+      "--disable-features=Translate,BackForwardCache",
+      "--start-maximized",
+      "--disable-extensions",
+      "--no-default-browser-check",
+      "--no-first-run",
+    ];
 
-  console.log("Creating a headless chromium instance...");
-  const browser = await chromium.launch({
-    // fix getting wiring SVGs
-    args: ["--disable-web-security"],
-    headless: ENV_HEADLESS_BROWSER,
-    proxy: ENV_USE_PROXY ? { server: "localhost:8888" } : undefined,
-  });
+    browser = await chromium.launch({
+      args: launchArgs,
+      headless: ENV_HEADLESS_BROWSER,
+      proxy: ENV_USE_PROXY ? { server: "localhost:8888" } : undefined,
+      // Remove obvious automation flags from the launched Chrome instance
+      ignoreDefaultArgs: ["--enable-automation"],
+    });
+  }
 
   // getBrowserContext applies modifications required for Headless Chrome to
   // work with PTS. This includes setting the User-Agent and sec-ch-ua headers,
   // and adding the cookies.
-  const getBrowserContext = async (): Promise<BrowserContext> => {
+  const viewport = { width: 1366, height: 768 } as const;
+
+  const applyStealthTweaks = async (context: BrowserContext) => {
+    // Run before any page scripts to mask common automation fingerprints
+    await context.addInitScript(() => {
+      Object.defineProperty(navigator, "webdriver", { get: () => undefined });
+      Object.defineProperty(navigator, "platform", { get: () => "Win32" });
+      Object.defineProperty(navigator, "language", { get: () => "en-US" });
+      Object.defineProperty(navigator, "languages", {
+        get: () => ["en-US", "en"],
+      });
+      Object.defineProperty(navigator, "hardwareConcurrency", {
+        get: () => 8,
+      });
+      Object.defineProperty(navigator, "deviceMemory", { get: () => 8 });
+      // window.chrome ??= { runtime: {} } as any;
+      Object.defineProperty(navigator, "plugins", {
+        get: () => [
+          { name: "Chrome PDF Plugin" },
+          { name: "Chrome PDF Viewer" },
+          { name: "Native Client" },
+        ],
+      });
+
+      // const originalQuery = window.navigator.permissions.query;
+      // window.navigator.permissions.query = (parameters) =>
+      //   parameters.name === "notifications"
+      //     ? Promise.resolve({ state: Notification.permission })
+      //     : originalQuery(parameters);
+
+      // Strip headless token if the UA ever includes it
+      if (navigator.userAgent.includes("HeadlessChrome")) {
+        const patchedUA = navigator.userAgent.replace(
+          "HeadlessChrome",
+          "Chrome"
+        );
+        Object.defineProperty(navigator, "userAgent", {
+          get: () => patchedUA,
+        });
+      }
+    });
+  };
+
+  const applyContextDefaults = async (
+    context: BrowserContext,
+    options: { applyStealth: boolean; addCookies: boolean }
+  ): Promise<void> => {
+    if (options.applyStealth) {
+      await applyStealthTweaks(context);
+
+      await context.route(
+        (url) => url.protocol !== "file:",
+        async (route) => {
+          const headers = await route.request().allHeaders();
+          headers["sec-ch-ua"] = SEC_CH_UA;
+          await route.continue({ headers });
+        }
+      );
+    }
+
+    if (options.addCookies && transformedCookies.length) {
+      await context.addCookies(transformedCookies);
+    }
+  };
+
+  const createManagedContext = async (): Promise<BrowserContext> => {
     const context = await browser.newContext({
       userAgent: USER_AGENT,
+      viewport,
+      screen: viewport,
+      deviceScaleFactor: 1,
+      locale: "en-US",
+      timezoneId: "America/New_York",
+      colorScheme: "light",
+      javaScriptEnabled: true,
+      ignoreHTTPSErrors: true,
       extraHTTPHeaders: {
-        // Without this, Playwright will put "HeadlessChrome" in here and PTS will reject the request
-        // When headers here conflict with default headers, the ones here take precedence.
-        // HOWEVER, these headers are only used for direct requests from `page.goto()`.
-        // This means that they are NOT used when the browser is redirected.
         "sec-ch-ua": SEC_CH_UA,
-        // TODO: Playwright bug: accept-language header not set in headless mode
-        "accept-language": `${config.workshop.contentlanguage.toLowerCase()}-${
-          config.workshop.contentmarket
-        },${config.workshop.contentlanguage.toLowerCase()};q=0.9`,
+        "accept-language": "en,zh-CN;q=0.9,zh;q=0.8",
       },
+      storageState: storageStateExists ? storageStatePath : undefined,
     });
-
-    // Mask the sec-ch-ua header on all non-file routes.
-    await context.route(
-      (url) => url.protocol !== "file:",
-      async (route) => {
-        const headers = await route.request().allHeaders();
-        headers["sec-ch-ua"] = SEC_CH_UA;
-        await route.continue({ headers });
-      }
-    );
-
-    // Add cookies
-    await context.addCookies(transformedCookies);
-
+    await applyContextDefaults(context, {
+      applyStealth: true,
+      addCookies: true,
+    });
     return context;
   };
 
-  const context = await getBrowserContext();
+  const getRemoteContext = async (): Promise<BrowserContext> => {
+    const existingContexts = browser.contexts();
+    if (!existingContexts.length) {
+      console.warn(
+        "No existing Chrome contexts were found. Creating a fresh one; log into PTS manually if needed."
+      );
+    }
+    const context =
+      existingContexts[0] ??
+      (await browser.newContext({
+        viewport,
+        screen: viewport,
+      }));
+    await applyContextDefaults(context, {
+      applyStealth: false,
+      addCookies: false,
+    });
+    return context;
+  };
+
+  const context = isRemoteBrowser
+    ? await getRemoteContext()
+    : await createManagedContext();
+
+  if (isRemoteBrowser) {
+    const remoteCookieHeader = await getCookieHeaderFromContext(context);
+    if (!remoteCookieHeader) {
+      console.error(
+        "Could not find any PTS cookies inside the connected Chrome session. " +
+          "Please log into PTS in that browser and try again."
+      );
+      process.exit(1);
+    }
+
+    rawCookieString = remoteCookieHeader.trim();
+    const cookieData = transformCookieString(rawCookieString);
+    transformedCookies = cookieData.transformedCookies;
+    processedCookieString = cookieData.processedCookieString;
+    setCookies(processedCookieString);
+    console.log("Loaded cookies from the active Chrome session.");
+  }
+
+  const addCookiesToContext = async (): Promise<void> => {
+    if (!isRemoteBrowser && transformedCookies.length) {
+      await context.addCookies(transformedCookies);
+    }
+  };
+
+  const preparePage = async (page: Page): Promise<void> => {
+    if (isRemoteBrowser) {
+      await page.setViewportSize(viewport);
+    }
+  };
 
   if (doCookieTest) {
     // no newline after write
     process.stdout.write("Attempting to log into PTS...");
     const cookieTestingPage = await context.newPage();
-    await cookieTestingPage.goto(
-      "https://www.fordtechservice.dealerconnection.com",
-      { waitUntil: "load" }
-    );
+    await preparePage(cookieTestingPage);
+
+    try {
+      await cookieTestingPage.goto(
+        "https://www.fordtechservice.dealerconnection.com",
+        { waitUntil: "load" }
+      );
+    } catch (e) {
+      // Wait until user presses enter
+      process.stdout.write("Press Enter to continue...");
+      await new Promise((resolve) => process.stdin.once("data", resolve));
+      console.log("Continuing...");
+
+      await cookieTestingPage.goto(
+        "https://www.fordtechservice.dealerconnection.com",
+        { waitUntil: "load" }
+      );
+    }
+
     if (cookieTestingPage.url().includes("subscriptionExpired")) {
       console.error(
         "Looks like your PTS subscription has expired. " +
@@ -136,9 +361,14 @@ async function run({
   if (doWorkshopDownload) {
     if (parseInt(config.workshop.modelYear) >= 2003) {
       const browserPage = await context.newPage();
+      await preparePage(browserPage);
       await browserPage.route("FordEcat.jpg", (route) => route.abort());
 
-      await modernWorkshop(config, outputPath, browserPage, restArgs);
+      try {
+        await modernWorkshop(config, outputPath, browserPage, saveOptions);
+      } finally {
+        await browserPage.close();
+      }
     } else {
       console.log(
         "Downloading pre-2003 workshop manual, please see README for details..."
@@ -154,16 +384,21 @@ async function run({
         process.exit(1);
       }
 
-      await context.addCookies(transformedCookies);
+      await addCookiesToContext();
       const browserPage = await context.newPage();
+      await preparePage(browserPage);
 
-      await pre2003Workshop(
-        config,
-        outputPath,
-        rawCookieString,
-        browserPage,
-        restArgs
-      );
+      try {
+        await pre2003Workshop(
+          config,
+          outputPath,
+          rawCookieString,
+          browserPage,
+          saveOptions
+        );
+      } finally {
+        await browserPage.close();
+      }
     }
 
     console.log("Saved workshop manual!");
@@ -174,8 +409,9 @@ async function run({
   if (doWiringDownload) {
     console.log("Saving wiring manual...");
 
-    await context.addCookies(transformedCookies);
+    await addCookiesToContext();
     const wiringPage = await context.newPage();
+    await preparePage(wiringPage);
 
     const wiringParams: WiringFetchParams = {
       ...config.wiring,
@@ -189,33 +425,43 @@ async function run({
 
     const wiringToC = await fetchTableOfContents(wiringParams);
 
-    await saveEntireWiring(
-      outputPath,
-      config.workshop,
-      wiringParams,
-      wiringToC,
-      wiringPage
-    );
+    try {
+      await saveEntireWiring(
+        outputPath,
+        config.workshop,
+        wiringParams,
+        wiringToC,
+        wiringPage
+      );
+    } finally {
+      await wiringPage.close();
+    }
   } else {
     console.log("Skipping wiring manual download.");
   }
 
-  console.log("Manual downloaded, closing browser");
-  await context.close();
-  await browser.close();
+  if (isRemoteBrowser) {
+    console.log("Manual downloaded, leaving remote Chrome session running.");
+  } else {
+    console.log("Manual downloaded, closing browser");
+    await context.storageState({ path: storageStatePath });
+    await context.close();
+    await browser.close();
+  }
 }
 
 async function modernWorkshop(
   config: Config,
   outputPath: string,
   browserPage: Page,
-  restArgs: any
+  saveOptions: SaveOptions
 ) {
   console.log("Downloading and processing table of contents...");
   const tocFetchParams: FetchTreeAndCoverParams = {
     ...config.workshop,
     CategoryDescription: "GSIXML",
-    category: "33",
+    category: "32",
+    environment: config.wiring.environment,
   };
   const { tableOfContents, pageHTML } = await fetchTreeAndCover(tocFetchParams);
 
@@ -232,7 +478,7 @@ async function modernWorkshop(
     tableOfContents,
     config.workshop,
     browserPage,
-    restArgs
+    saveOptions
   );
 }
 
@@ -241,7 +487,7 @@ async function pre2003Workshop(
   outputPath: string,
   rawCookieString: string,
   browserPage: Page,
-  restArgs: any
+  saveOptions: SaveOptions
 ) {
   console.log("Downloading and processing alphabetical index...");
   const { documentList, pageHTML, modifiedHTML } =
@@ -268,7 +514,7 @@ async function pre2003Workshop(
     outputPath,
     documentList,
     browserPage,
-    restArgs
+    saveOptions
   );
 }
 

--- a/src/workshop/fetchTreeAndCover.ts
+++ b/src/workshop/fetchTreeAndCover.ts
@@ -6,14 +6,21 @@ import { JSDOM } from "jsdom";
 export interface FetchTreeAndCoverParams extends FetchManualPageParams {
   CategoryDescription: string;
   category: string;
+  environment?: string;
 }
 
 export default async function fetchTreeAndCover(
   params: FetchTreeAndCoverParams
 ): Promise<{ tableOfContents: any; pageHTML: string }> {
+  const _params = {
+    ...params,
+  };
+  // Only used in the path (not in query string)
+  delete _params.environment;
+
   const req = await client({
     method: "POST",
-    url: `https://www.fordservicecontent.com/Ford_Content/PublicationRuntimeRefreshPTS//publication/prod_1_3_362022/TreeAndCover/workshop/${params.category}/~WS8B/${params.vehicleId}`,
+    url: `https://www.fordservicecontent.com/Ford_Content/PublicationRuntimeRefreshPTS//publication/${params.environment}/TreeAndCover/workshop/${params.category}/~WSMX/${params.vehicleId}`,
     params: {
       bookTitle: params.bookTitle,
       WiringBookTitle: params.WiringBookTitle,

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,10 +124,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^17.0.21":
+"@types/node@npm:*":
   version: 17.0.24
   resolution: "@types/node@npm:17.0.24"
   checksum: 10/9ce4e01d2393e326cb93269034952fe394e8aa8cca887af1ae634c3806db6b452d4b50727fbbd0b0e6407d1ade0ff77032ebd1076c0391192d20bd8df4f68846
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^17.0.21":
+  version: 17.0.45
+  resolution: "@types/node@npm:17.0.45"
+  checksum: 10/b45fff7270b5e81be19ef91a66b764a8b21473a97a8d211218a52e3426b79ad48f371819ab9153370756b33ba284e5c875463de4d2cf48a472e9098d7f09e8a2
   languageName: node
   linkType: hard
 
@@ -828,7 +835,7 @@ __metadata:
     command-line-args: "npm:^5.2.1"
     command-line-usage: "npm:^6.1.1"
     jsdom: "npm:^19.0.0"
-    playwright: "npm:^1.42.1"
+    playwright: "npm:^1.57.0"
     prettier: "npm:^2.5.1"
     qs: "npm:^6.10.3"
     svg-to-img: "npm:^2.0.9"
@@ -1546,27 +1553,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.44.1":
-  version: 1.44.1
-  resolution: "playwright-core@npm:1.44.1"
+"playwright-core@npm:1.57.0":
+  version: 1.57.0
+  resolution: "playwright-core@npm:1.57.0"
   bin:
     playwright-core: cli.js
-  checksum: 10/f79f9022bbb760daed371e36c802b27d43dc75e67de4d139d83b47feea51c8b884f3296cce85c3afa71c942290cef1b4369cd9ddf4dda5457a0a81772c73b50a
+  checksum: 10/ec066602f0196f036006caee14a30d0a57533a76673bb9a0c609ef56e21decf018f0e8d402ba2fb18251393be6a1c9e193c83266f1670fe50838c5340e220de0
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.42.1":
-  version: 1.44.1
-  resolution: "playwright@npm:1.44.1"
+"playwright@npm:^1.57.0":
+  version: 1.57.0
+  resolution: "playwright@npm:1.57.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.44.1"
+    playwright-core: "npm:1.57.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10/3207178a78f1c971dddf99c9a08052e462c882092e0d47e3dd8287ced40897a49e387e545a61d31e5d68f7e443d7818660aa12ce43ab662d01d95bcfcfeca2ca
+  checksum: 10/241559210f98ef11b6bd6413f2d29da7ef67c7865b72053192f0d164fab9e0d3bd47913b3351d5de6433a8aff2d8424d4b8bd668df420bf4dda7ae9fcd37b942
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Love the work already done here! Like many folks, I would like to have persistent manuals for my Transit and Mustang builds, but seems always ran into `ERR_HTTP2_PROTOCOL_ERROR`. 

I then tried to use the same Chromium instance to perform an interactive login flow (https://www.motorcraftservice.com/Home/Login) - I also saw a `ERR_HTTP2_PROTOCOL_ERROR`. That's the moment I realise that Ford may have gotten stricter on headless/automation seesion (or even if not the direct cause - still could in the future), so I built a mode that hooks into a normal Chrome session via remote debugging.

This approach has served me very well with downloading 2021 Ford Transit and 2017 Ford Mustang.

---

- add CLI flags `--browserMode` (`managed` default, `remote` new) and `--remoteDebuggingUrl`
- allow the downloader to skip launching Playwright’s Chromium and instead attach to an already running Chrome via CDP
- (When using `remote`) reuse cookies harvested from the connected Chrome session so users no longer have to paste headers into `cookieString.txt`
- document the managed vs. remote modes in the README with setup instructions for remote debugging Chrome


I have made sure these are good:
  - `yarn tsc --noEmit`
  - `yarn format`