### PR TITLE
Fix wiring downloads for 2020+ vehicles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,8 @@ async function run({
       config.workshop,
       wiringParams,
       wiringToC,
-      wiringPage
+      wiringPage,
+      restArgs.ignoreSaveErrors
     );
   } else {
     console.log("Skipping wiring manual download.");

--- a/src/wiring/saveEntireWiring.ts
+++ b/src/wiring/saveEntireWiring.ts
@@ -19,7 +19,8 @@ export default async function saveEntireWiring(
   fetchManualParams: FetchManualPageParams,
   fetchWiringParams: WiringFetchParams,
   toc: WiringTableOfContentsEntry[],
-  browserPage: Page
+  browserPage: Page,
+  ignoreSaveErrors: boolean = false
 ) {
   const wiringPath = join(path, "Wiring");
   try {
@@ -66,14 +67,24 @@ export default async function saveEntireWiring(
       country: fetchManualParams.country,
     };
 
-    if (isPage(doc) || isBasicPage(doc)) {
-      await savePage(wiringFetchParams, doc, browserPage, sectionPath);
-    } else if (isConnectors(doc)) {
-      await saveConnector(wiringFetchParams, doc, browserPage, connectorPath);
-    } else if (isLocIndex(doc)) {
-      await saveLocIndex(wiringFetchParams, doc, connectorPath);
-    } else {
-      console.error(`Unrecognized wiring page type ${doc.Type}`, doc);
+    try {
+      if (isPage(doc) || isBasicPage(doc)) {
+        await savePage(wiringFetchParams, doc, browserPage, sectionPath, ignoreSaveErrors);
+      } else if (isConnectors(doc)) {
+        await saveConnector(wiringFetchParams, doc, browserPage, connectorPath);
+      } else if (isLocIndex(doc)) {
+        await saveLocIndex(wiringFetchParams, doc, connectorPath);
+      } else {
+        console.error(`Unrecognized wiring page type ${doc.Type}`, doc);
+      }
+    } catch (e: any) {
+      if (ignoreSaveErrors) {
+        console.error(
+          `Skipping ${doc.Title} (${doc.Type}) due to error: ${e.message}`
+        );
+      } else {
+        throw e;
+      }
     }
   }
 }

--- a/src/wiring/savePage.ts
+++ b/src/wiring/savePage.ts
@@ -9,7 +9,6 @@ import fetchSvg from "./fetchSvg";
 import { join, resolve } from "path";
 import { writeFile } from "fs/promises";
 import { sanitizeName } from "../utils";
-import fetchBasicPage from "./fetchBasicPage";
 
 export interface WiringFetchPageParams extends WiringFetchParams {
   vehicleId: string;
@@ -22,11 +21,9 @@ export default async function savePage(
     | (WiringTableOfContentsEntry & { Type: "Page" })
     | (WiringTableOfContentsEntry & { Type: "BasicPage" }),
   browserPage: Page,
-  folderPath: string
+  folderPath: string,
+  ignoreSaveErrors: boolean = false
 ): Promise<void> {
-  // Need pageList per docNumber
-  // Page lists for "Page" type documents is returned as ["001, "002", "003", etc]
-
   const pageList = await fetchPageList({
     ...params,
     cell: doc.Number,
@@ -39,62 +36,86 @@ export default async function savePage(
     JSON.stringify(pageList, null, 2)
   );
 
-  for (const subPage of pageList) {
-    console.log(`Saving page ${subPage} of ${doc.Title}...`);
+  for (const subPage of pageList as any[]) {
+    let pageNumber: string | null = null;
 
-    if (typeof subPage !== "string") {
-      // page is a BasicPagePageListItem, download PDF
-      const pdfPath = join(folderPath, `${subPage.Text}.pdf`);
-
-      await fetchBasicPage(pdfPath, params.book);
-      continue;
+    if (typeof subPage === "string") {
+      pageNumber = subPage;
+    } else if (subPage && typeof subPage === "object") {
+      // Current Ford format: {cell, page, Code, Startdate, Enddate}
+      if ("page" in subPage && subPage.page) {
+        pageNumber = String(subPage.page);
+      } else if ("Value" in subPage && subPage.Value) {
+        // Legacy BasicPage format - skip
+        console.warn(
+          `  Skipping legacy BasicPage subpage in ${doc.Title}`
+        );
+        continue;
+      }
     }
 
-    const svg = await fetchSvg(
-      doc.Number,
-      subPage,
-      params.environment,
-      params.vehicleId,
-      params.book,
-      params.languageCode
-    );
-
-    // parse the SVG into a DOM for manipulation
-    const dom = new JSDOM(svg);
-    const svgElement = dom.window.document.querySelector("svg");
-    if (!svgElement) {
-      console.error(
-        `No SVG element found in Wiring SVG for ${doc.Title} ${subPage}`
+    if (!pageNumber) {
+      console.warn(
+        `  Skipping unrecognized subpage format in ${doc.Title}: ${JSON.stringify(
+          subPage
+        )}`
       );
       continue;
     }
 
-    svgElement.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    try {
+      console.log(`Saving page ${pageNumber} of ${doc.Title}...`);
 
-    let title = subPage;
+      const svg = await fetchSvg(
+        doc.Number,
+        pageNumber,
+        params.environment,
+        params.vehicleId,
+        params.book,
+        params.languageCode
+      );
 
-    const headerElement = dom.window.document.getElementById("Header");
-    if (headerElement) {
-      const child = headerElement.firstElementChild;
-      if (child && child.textContent) {
-        title += ` ${sanitizeName(child.textContent)}`;
+      const dom = new JSDOM(svg);
+      const svgElement = dom.window.document.querySelector("svg");
+      if (!svgElement) {
+        console.error(
+          `  No SVG element found in Wiring SVG for ${doc.Title} ${pageNumber}`
+        );
+        continue;
       }
+
+      svgElement.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+
+      let title = pageNumber;
+
+      const headerElement = dom.window.document.getElementById("Header");
+      if (headerElement) {
+        const child = headerElement.firstElementChild;
+        if (child && child.textContent) {
+          title += ` ${sanitizeName(child.textContent)}`;
+        }
+      }
+
+      const svgString = dom.serialize();
+
+      const svgPath = join(folderPath, `${title}.svg`);
+      await writeFile(svgPath, svgString);
+
+      const pdfPath = join(folderPath, `${title}.pdf`);
+
+      await browserPage.goto(`file:///${encodeURI(resolve(svgPath))}`);
+      await browserPage.pdf({
+        path: pdfPath,
+        landscape: true,
+      });
+    } catch (e: any) {
+      if (ignoreSaveErrors) {
+        console.error(
+          `  Failed to save subpage ${pageNumber} of ${doc.Title}: ${e.message}`
+        );
+        continue;
+      }
+      throw e;
     }
-
-    const svgString = dom.serialize();
-
-    // Save the SVG
-    const svgPath = join(folderPath, `${title}.svg`);
-    await writeFile(svgPath, svgString);
-
-    // Print as PDF
-    const pdfPath = join(folderPath, `${title}.pdf`);
-
-    // can't use getSvgUrl here because the SVG is too big
-    await browserPage.goto(`file:///${resolve(svgPath)}`);
-    await browserPage.pdf({
-      path: pdfPath,
-      landscape: true,
-    });
   }
 }


### PR DESCRIPTION
Fetching wiring schematics has been broken for any vehicle where Ford has migrated to the current pageList API shape. This came up when trying to pull a 2021 Explorer and again on a 2024 F-250 Super Duty — both failed at the first wiring section with the page list response not matching either expected interface.

## What's broken

\`fetchPageList\` returns one of three shapes depending on vehicle/era:

1. \`string[]\` — legacy SVG pages, just an array of page numbers
2. \`{Value, Text}[]\` — legacy BasicPage interface (per the existing TypeScript types)
3. \`{cell, page, Code, Startdate, Enddate}[]\` — current Ford format for SVG schematics, what every modern vehicle returns

The existing code only handled (1). For (3), \`typeof subPage !== "string"\` falls through to the BasicPage branch, which then constructs a malformed URL by treating the local pdfPath as the remote filename, and discards the returned ReadableStream without writing it to disk. Net effect: every wiring page crashes the script before any schematic gets saved.

## What this PR changes

**Commit 1 — Fix wiring schematic fetching for 2020+ vehicles**
- Detect all three pageList formats explicitly, extract \`subPage.page\` for the current Ford format
- Skip legacy \`{Value, Text}\` BasicPage entries with a warning instead of crashing on the broken code path. The original BasicPage handling has separate bugs (URL construction passing local paths, response stream never piped to file) that I didn't try to fix here since I don't have a pre-2003 vehicle to verify against
- URL-encode local SVG paths before \`browserPage.goto(file://...)\`. Some Super Duty page titles contain \`#\` (e.g. "DUAL ALTERNATOR - WITHOUT POWER INVERTER #2") which gets parsed as a URL fragment and breaks PDF rendering, even though the file exists on disk

**Commit 2 — Honor \`--ignoreSaveErrors\` flag for wiring downloads**
- The flag was already plumbed through workshop and pre-2003 paths but never reached wiring. A single 404 in the middle of a long wiring run aborted everything and discarded prior progress. Pass \`ignoreSaveErrors\` through \`saveEntireWiring\` → \`savePage\` and gate the per-doc and per-subpage catches on it. Default is \`false\`, so behavior without the flag is unchanged

## Tested

- 2021 Ford Explorer (SMN/EMN) — full workshop + wiring run, ~1500 wiring PDFs, no errors
- 2024 Ford F-250 Super Duty 6.8L (S9516/E240ON) — full workshop + wiring run, six PDFs missing only because the encodeURI fix was added partway through; rerunning would catch them. SVGs for those six saved fine.

## Notes for review

- The \`pageList as any[]\` cast is intentional; the underlying API genuinely returns three different shapes and the existing \`BasicPagePageListItem\` interface doesn't reflect what's actually being returned. A cleaner fix would update the typed interface in \`fetchPageList.ts\` to a discriminated union, but I left that out to keep this PR focused on getting modern vehicles working again
- BasicPage handling is now effectively a no-op with a warning. If anyone has a pre-2003 vehicle and a working PTS sub, the BasicPage path needs a separate look — at minimum the stream-to-file plumbing and the URL builder both need fixing, and the actual API response shape verified